### PR TITLE
Add support for HTTPOption

### DIFF
--- a/config/config-gateway.yaml
+++ b/config/config-gateway.yaml
@@ -50,6 +50,7 @@ data:
       - class: istio
         gateway: istio-system/knative-gateway
         service: istio-system/istio-ingressgateway
+        http-listener-name: http
         supported-features:
         - HTTPRouteRequestTimeout
 
@@ -58,5 +59,6 @@ data:
       - class: istio
         gateway: istio-system/knative-local-gateway
         service: istio-system/knative-local-gateway
+        http-listener-name: http
         supported-features:
         - HTTPRouteRequestTimeout

--- a/docs/test-version.md
+++ b/docs/test-version.md
@@ -15,5 +15,5 @@ The following Gateway API version and Ingress were tested as part of the release
 
 | Ingress | Tested version          | Unavailable features           |
 | ------- | ----------------------- | ------------------------------ |
-| Istio   | v1.22.1     | retry,httpoption   |
-| Contour | v1.29.1    | httpoption |
+| Istio   | v1.22.1     | retry   |
+| Contour | v1.29.1    |  |

--- a/hack/test-env.sh
+++ b/hack/test-env.sh
@@ -16,9 +16,9 @@
 
 export GATEWAY_API_VERSION="v1.1.0"
 export ISTIO_VERSION="1.22.1"
-export ISTIO_UNSUPPORTED_E2E_TESTS="retry,httpoption"
+export ISTIO_UNSUPPORTED_E2E_TESTS="retry"
 export CONTOUR_VERSION="v1.29.1"
-export CONTOUR_UNSUPPORTED_E2E_TESTS="httpoption"
+export CONTOUR_UNSUPPORTED_E2E_TESTS=""
 
 export ENVOY_GATEWAY_VERSION="latest"
-export ENVOY_GATEWAY_UNSUPPORTED_E2E_TESTS="httpoption,host-rewrite"
+export ENVOY_GATEWAY_UNSUPPORTED_E2E_TESTS="host-rewrite"

--- a/hack/test-env.sh
+++ b/hack/test-env.sh
@@ -21,4 +21,5 @@ export CONTOUR_VERSION="v1.29.1"
 export CONTOUR_UNSUPPORTED_E2E_TESTS=""
 
 export ENVOY_GATEWAY_VERSION="latest"
-export ENVOY_GATEWAY_UNSUPPORTED_E2E_TESTS="host-rewrite"
+# hostoption does not work because of a bug in envoy-gateway: https://github.com/envoyproxy/gateway/issues/2149
+export ENVOY_GATEWAY_UNSUPPORTED_E2E_TESTS="httpoption,host-rewrite"

--- a/hack/test-env.sh
+++ b/hack/test-env.sh
@@ -21,5 +21,4 @@ export CONTOUR_VERSION="v1.29.1"
 export CONTOUR_UNSUPPORTED_E2E_TESTS=""
 
 export ENVOY_GATEWAY_VERSION="latest"
-# hostoption does not work because of a bug in envoy-gateway: https://github.com/envoyproxy/gateway/issues/2149
-export ENVOY_GATEWAY_UNSUPPORTED_E2E_TESTS="httpoption,host-rewrite"
+export ENVOY_GATEWAY_UNSUPPORTED_E2E_TESTS="host-rewrite"

--- a/pkg/reconciler/ingress/config/gateway.go
+++ b/pkg/reconciler/ingress/config/gateway.go
@@ -47,6 +47,7 @@ func defaultExternalGateways() []Gateway {
 			Name:      "istio-ingressgateway",
 			Namespace: "istio-system",
 		},
+		HTTPListenerName: "http",
 		SupportedFeatures: sets.New(
 			features.SupportHTTPRouteRequestTimeout,
 		),
@@ -64,6 +65,7 @@ func defaultLocalGateways() []Gateway {
 			Name:      "knative-local-gateway",
 			Namespace: "istio-system",
 		},
+		HTTPListenerName: "http",
 		SupportedFeatures: sets.New(
 			features.SupportHTTPRouteRequestTimeout,
 		),
@@ -90,6 +92,7 @@ type Gateway struct {
 	types.NamespacedName
 
 	Class             string
+	HTTPListenerName  string
 	Service           *types.NamespacedName
 	SupportedFeatures sets.Set[features.SupportedFeature]
 }
@@ -138,6 +141,7 @@ type gatewayEntry struct {
 	Gateway           string                      `json:"gateway"`
 	Service           *string                     `json:"service"`
 	Class             string                      `json:"class"`
+	HTTPListenerName  string                      `json:"http-listener-name"`
 	SupportedFeatures []features.SupportedFeature `json:"supported-features"`
 }
 
@@ -152,6 +156,7 @@ func parseGatewayConfig(data string) ([]Gateway, error) {
 	for i, entry := range entries {
 		gw := Gateway{
 			Class:             entry.Class,
+			HTTPListenerName:  entry.HTTPListenerName,
 			SupportedFeatures: sets.New(entry.SupportedFeatures...),
 		}
 
@@ -173,6 +178,9 @@ func parseGatewayConfig(data string) ([]Gateway, error) {
 		}
 		if len(strings.TrimSpace(gw.Class)) == 0 {
 			return nil, fmt.Errorf(`entry [%d] field "class" is required`, i)
+		}
+		if len(strings.TrimSpace(gw.HTTPListenerName)) == 0 {
+			return nil, fmt.Errorf(`entry [%d] field "http-listener-name" is required`, i)
 		}
 
 		gws = append(gws, gw)

--- a/pkg/reconciler/ingress/config/gateway_test.go
+++ b/pkg/reconciler/ingress/config/gateway_test.go
@@ -21,11 +21,11 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	. "knative.dev/pkg/configmap/testing"
+	ktesting "knative.dev/pkg/configmap/testing"
 )
 
 func TestFromConfigMap(t *testing.T) {
-	cm, example := ConfigMapsFromTestFile(t, GatewayConfigName)
+	cm, example := ktesting.ConfigMapsFromTestFile(t, GatewayConfigName)
 
 	if _, err := FromConfigMap(cm); err != nil {
 		t.Error("FromConfigMap(actual) =", err)

--- a/pkg/reconciler/ingress/config/gateway_test.go
+++ b/pkg/reconciler/ingress/config/gateway_test.go
@@ -58,9 +58,11 @@ func TestFromConfigMapErrors(t *testing.T) {
 		data: map[string]string{
 			"external-gateways": `[{
 					"class":"boo",
+					"http-listener-name":"http",
 					"gateway": "ns/n"
 				},{
 					"class":"boo",
+					"http-listener-name":"http",
 					"gateway": "ns/n"
 				}]`,
 		},
@@ -70,9 +72,11 @@ func TestFromConfigMapErrors(t *testing.T) {
 		data: map[string]string{
 			"local-gateways": `[{
 					"class":"boo",
+					"http-listener-name":"http",
 					"gateway": "ns/n"
 				},{
 					"class":"boo",
+					"http-listener-name":"http",
 					"gateway": "ns/n"
 				}]`,
 		},
@@ -119,6 +123,12 @@ func TestFromConfigMapErrors(t *testing.T) {
 			"local-gateways": `[{"class": "class", "gateway": "ns/n", "service":"name"}]`,
 		},
 		want: `unable to parse "local-gateways"`,
+	}, {
+		name: "missing gateway http-listener-name",
+		data: map[string]string{
+			"local-gateways": `[{"class":"class", "gateway": "namespace/name"}]`,
+		},
+		want: `unable to parse "local-gateways": entry [0] field "http-listener-name" is required`,
 	}}
 
 	for _, tc := range cases {
@@ -141,9 +151,11 @@ func TestGatewayNoService(t *testing.T) {
 		Data: map[string]string{
 			"external-gateways": `
       - class: istio
+        http-listener-name: http
         gateway: istio-system/knative-gateway`,
 			"local-gateways": `
       - class: istio
+        http-listener-name: http
         gateway: istio-system/knative-local-gateway`,
 		},
 	})

--- a/pkg/reconciler/ingress/controller_test.go
+++ b/pkg/reconciler/ingress/controller_test.go
@@ -33,11 +33,11 @@ import (
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 
-	. "knative.dev/pkg/reconciler/testing"
+	ktesting "knative.dev/pkg/reconciler/testing"
 )
 
 func TestNew(t *testing.T) {
-	ctx, _ := SetupFakeContext(t)
+	ctx, _ := ktesting.SetupFakeContext(t)
 
 	c := NewController(ctx, configmap.NewStaticWatcher(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgotesting "k8s.io/client-go/testing"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 
 	fakegwapiclientset "knative.dev/net-gateway-api/pkg/client/injection/client/fake"
@@ -197,7 +196,7 @@ func TestReconcile(t *testing.T) {
 		// no extra update
 	}}
 
-	table.Test(t, gwtesting.MakeFactory(func(ctx context.Context, listers *gwtesting.Listers, cmw configmap.Watcher) controller.Reconciler {
+	table.Test(t, gwtesting.MakeFactory(func(ctx context.Context, listers *gwtesting.Listers, _ configmap.Watcher) controller.Reconciler {
 		r := &Reconciler{
 			gwapiclient: fakegwapiclientset.Get(ctx),
 			// Listers index properties about resources
@@ -368,7 +367,7 @@ func TestReconcileTLS(t *testing.T) {
 		},
 	}}
 
-	table.Test(t, GatewayFactory(func(ctx context.Context, listers *gwtesting.Listers, cmw configmap.Watcher, tr *ktesting.TableRow) controller.Reconciler {
+	table.Test(t, GatewayFactory(func(ctx context.Context, listers *gwtesting.Listers, _ configmap.Watcher, tr *ktesting.TableRow) controller.Reconciler {
 		r := &Reconciler{
 			gwapiclient:          fakegwapiclientset.Get(ctx),
 			httprouteLister:      listers.GetHTTPRouteLister(),
@@ -2158,7 +2157,7 @@ func TestReconcileProbing(t *testing.T) {
 					Version: "tr-9333a9a68409bb44f2a5f538d2d7c617e5338b6b6c1ebc5e00a19612a5c962c2",
 				}, false
 			},
-			FakeDoProbes: func(ctx context.Context, s status.Backends) (status.ProbeState, error) {
+			FakeDoProbes: func(_ context.Context, s status.Backends) (status.ProbeState, error) {
 				state := status.ProbeState{}
 				expectedHash := "tr-9333a9a68409bb44f2a5f538d2d7c617e5338b6b6c1ebc5e00a19612a5c962c2"
 
@@ -2221,7 +2220,7 @@ func TestReconcileProbing(t *testing.T) {
 		WantUpdates: nil, // No updates
 	}}
 
-	table.Test(t, gwtesting.MakeFactory(func(ctx context.Context, listers *gwtesting.Listers, cmw configmap.Watcher) controller.Reconciler {
+	table.Test(t, gwtesting.MakeFactory(func(ctx context.Context, listers *gwtesting.Listers, _ configmap.Watcher) controller.Reconciler {
 		statusManager := ctx.Value(fakeStatusKey).(status.Manager)
 		r := &Reconciler{
 			gwapiclient: fakegwapiclientset.Get(ctx),
@@ -2356,7 +2355,7 @@ func TestReconcileProbingOffClusterGateway(t *testing.T) {
 			})}},
 	}}
 
-	table.Test(t, gwtesting.MakeFactory(func(ctx context.Context, listers *gwtesting.Listers, cmw configmap.Watcher) controller.Reconciler {
+	table.Test(t, gwtesting.MakeFactory(func(ctx context.Context, listers *gwtesting.Listers, _ configmap.Watcher) controller.Reconciler {
 		statusManager := ctx.Value(fakeStatusKey).(status.Manager)
 		r := &Reconciler{
 			gwapiclient: fakegwapiclientset.Get(ctx),
@@ -2551,10 +2550,10 @@ func tlsListener(hostname, nsName, secretName string) GatewayOption {
 			Port:     443,
 			Protocol: "HTTPS",
 			TLS: &gatewayapi.GatewayTLSConfig{
-				Mode: (*gatewayapi.TLSModeType)(pointer.String("Terminate")),
+				Mode: (*gatewayapi.TLSModeType)(ptr.To("Terminate")),
 				CertificateRefs: []gatewayapi.SecretObjectReference{{
-					Group:     (*gatewayapi.Group)(pointer.String("")),
-					Kind:      (*gatewayapi.Kind)(pointer.String("Secret")),
+					Group:     (*gatewayapi.Group)(ptr.To("")),
+					Kind:      (*gatewayapi.Kind)(ptr.To("Secret")),
 					Name:      gatewayapi.ObjectName(secretName),
 					Namespace: (*gatewayapi.Namespace)(&nsName),
 				}},
@@ -2562,7 +2561,7 @@ func tlsListener(hostname, nsName, secretName string) GatewayOption {
 			},
 			AllowedRoutes: &gatewayapi.AllowedRoutes{
 				Namespaces: &gatewayapi.RouteNamespaces{
-					From: (*gatewayapi.FromNamespaces)(pointer.String("Selector")),
+					From: (*gatewayapi.FromNamespaces)(ptr.To("Selector")),
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"kubernetes.io/metadata.name": nsName,

--- a/pkg/reconciler/ingress/lister_test.go
+++ b/pkg/reconciler/ingress/lister_test.go
@@ -36,7 +36,7 @@ import (
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/kmeta"
 
-	. "knative.dev/net-gateway-api/pkg/reconciler/testing"
+	rtesting "knative.dev/net-gateway-api/pkg/reconciler/testing"
 )
 
 var (
@@ -256,7 +256,7 @@ func TestBackendsToProbeTargets(t *testing.T) {
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-			tl := NewListers(test.objects)
+			tl := rtesting.NewListers(test.objects)
 
 			l := &gatewayPodTargetLister{
 				endpointsLister: tl.GetEndpointsLister(),
@@ -404,7 +404,7 @@ func TestListProbeTargetsNoService(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tl := NewListers(test.objects)
+			tl := rtesting.NewListers(test.objects)
 
 			l := &gatewayPodTargetLister{
 				endpointsLister: tl.GetEndpointsLister(),
@@ -596,6 +596,10 @@ func withBackendAppendHeaders(key, val string) IngressOption {
 	return func(i *v1alpha1.Ingress) {
 		i.Spec.Rules[0].HTTP.Paths[0].Splits[0].AppendHeaders[key] = val
 	}
+}
+
+func withHTTPOptionRedirected(i *v1alpha1.Ingress) {
+	i.Spec.HTTPOption = v1alpha1.HTTPOptionRedirected
 }
 
 func withInternalSpec(i *v1alpha1.Ingress) {

--- a/pkg/reconciler/ingress/resources/httproute.go
+++ b/pkg/reconciler/ingress/resources/httproute.go
@@ -461,7 +461,7 @@ func matchesFromRulePath(path netv1alpha1.HTTPIngressPath) []gatewayapi.HTTPRout
 		Value: ptr.To(pathPrefix),
 	}
 
-	var headerMatchList []gatewayapi.HTTPHeaderMatch
+	var headerMatchList []gatewayapi.HTTPHeaderMatch //nolint:all
 	for k, v := range path.Headers {
 		headerMatch := gatewayapi.HTTPHeaderMatch{
 			Type:  ptr.To(gatewayapi.HeaderMatchExact),

--- a/pkg/reconciler/ingress/resources/httproute_test.go
+++ b/pkg/reconciler/ingress/resources/httproute_test.go
@@ -1193,6 +1193,36 @@ func TestMakeRedirectHTTPRoute(t *testing.T) {
 		expected []*gatewayapi.HTTPRoute
 	}{
 		{
+			name: "cluster local domain only",
+			ing: &v1alpha1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testIngressName,
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						networking.IngressLabelKey: testIngressName,
+					},
+				},
+				Spec: v1alpha1.IngressSpec{
+					Rules: []v1alpha1.IngressRule{
+						{
+							Hosts:      testLocalHosts,
+							Visibility: v1alpha1.IngressVisibilityClusterLocal,
+							HTTP: &v1alpha1.HTTPIngressRuleValue{
+								Paths: []v1alpha1.HTTPIngressPath{{
+									Splits: []v1alpha1.IngressBackendSplit{{
+										IngressBackend: v1alpha1.IngressBackend{
+											ServiceName: "goo",
+											ServicePort: intstr.FromInt(123),
+										},
+										Percent: 100,
+									}},
+								}},
+							},
+						},
+					}},
+			},
+			expected: []*gatewayapi.HTTPRoute{},
+		}, {
 			name: "single external domain and cluster local",
 			ing: &v1alpha1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/testdata/contour-no-service-vis.yaml
+++ b/test/e2e/testdata/contour-no-service-vis.yaml
@@ -27,11 +27,13 @@ data:
   external-gateways: |
     - class: contour-external
       gateway: contour-external/knative-external
+      http-listener-name: http
       supported-features:
       - HTTPRouteRequestTimeout
   local-gateways: |
     - class: contour-internal
       gateway: contour-internal/knative-local
       service: contour-internal/envoy-knative-local
+      http-listener-name: http
       supported-features:
       - HTTPRouteRequestTimeout

--- a/test/e2e/testdata/envoy-gateway-no-service-vis.yaml
+++ b/test/e2e/testdata/envoy-gateway-no-service-vis.yaml
@@ -25,6 +25,7 @@ data:
   external-gateways: |
     - class: eg-external
       gateway: eg-external/eg-external
+      http-listener-name: http
       supported-features:
       - HTTPRouteRequestTimeout
 
@@ -33,5 +34,6 @@ data:
     - class: eg-internal
       gateway: eg-internal/eg-internal
       service: envoy-gateway-system/knative-internal
+      http-listener-name: http
       supported-features:
       - HTTPRouteRequestTimeout

--- a/test/e2e/testdata/istio-no-service-vis.yaml
+++ b/test/e2e/testdata/istio-no-service-vis.yaml
@@ -23,10 +23,12 @@ data:
   external-gateways: |
     - class: istio
       gateway: istio-system/knative-gateway
+      http-listener-name: http
       supported-features:
       - HTTPRouteRequestTimeout
   local-gateways: |
     - class: istio
       gateway: istio-system/knative-local-gateway
+      http-listener-name: http
       supported-features:
       - HTTPRouteRequestTimeout

--- a/third_party/contour/config-gateway.yaml
+++ b/third_party/contour/config-gateway.yaml
@@ -26,6 +26,7 @@ data:
     - class: contour-external
       gateway: contour-external/knative-external
       service: contour-external/envoy-knative-external
+      http-listener-name: http
       supported-features:
       - HTTPRouteRequestTimeout
 
@@ -34,5 +35,6 @@ data:
     - class: contour-internal
       gateway: contour-internal/knative-local
       service: contour-internal/envoy-knative-local
+      http-listener-name: http
       supported-features:
       - HTTPRouteRequestTimeout

--- a/third_party/envoy-gateway/config-gateway.yaml
+++ b/third_party/envoy-gateway/config-gateway.yaml
@@ -26,6 +26,7 @@ data:
     - class: eg-external
       gateway: eg-external/eg-external
       service: envoy-gateway-system/knative-external
+      http-listener-name: http
       supported-features:
       - HTTPRouteRequestTimeout
 
@@ -34,5 +35,6 @@ data:
     - class: eg-internal
       gateway: eg-internal/eg-internal
       service: envoy-gateway-system/knative-internal
+      http-listener-name: http
       supported-features:
       - HTTPRouteRequestTimeout

--- a/third_party/istio/300-gateway-local.yaml
+++ b/third_party/istio/300-gateway-local.yaml
@@ -23,7 +23,7 @@ spec:
   - type: Hostname
     value: knative-local-gateway
   listeners:
-  - name: default
+  - name: http
     port: 80
     protocol: HTTP
     allowedRoutes:

--- a/third_party/istio/300-gateway.yaml
+++ b/third_party/istio/300-gateway.yaml
@@ -23,7 +23,7 @@ spec:
   - type: Hostname
     value: istio-ingressgateway
   listeners:
-  - name: default
+  - name: http
     port: 80
     protocol: HTTP
     allowedRoutes:


### PR DESCRIPTION
This PR introduces support for HTTPOption (introduced in https://github.com/knative/networking/pull/415).

# Changes
- :gift: Add support for HTTPOption
- :gift: Introduces a new configuration to specify the name of the http-listener for the gateways
- :broom: Cleanup some redundancies in test code
- :broom: Use new functions where deprecations were used 

The implementation is based on the gateway-api example for redirects: https://github.com/kubernetes-sigs/gateway-api/blob/main/examples/standard/http-redirect.yaml. It was necessary to restructure some code, as two `HTTPRoute` objects need to be created, each referencing only a specific section in the `gateway` using `sectionName`. We should further discuss if we should use that approach also for the "normal" use-case (as we currently bind to all the sections in the gateway only differentiated by the `hostname` in the TLS case). Also The configuration key `visibility` seems now a bit off, maybe we can find a better name?

A full example of how the resources look like can be found here: https://gist.github.com/ReToCode/2e4d2b3223752c6f380348ef027c55b3

/kind cleanup
/kind enhancement

Fixes #130
