### PR TITLE
Bump Istio to 1.19.3

### DIFF
--- a/docs/test-version.md
+++ b/docs/test-version.md
@@ -15,5 +15,5 @@ The following Gateway API version and Ingress were tested as part of the release
 
 | Ingress | Tested version          | Unavailable features           |
 | ------- | ----------------------- | ------------------------------ |
-| Istio   | v1.19.0     | retry,httpoption   |
+| Istio   | v1.19.3     | retry,httpoption   |
 | Contour | v1.26.0    | httpoption,basics/http2,grpc,grpc/split,update |

--- a/hack/test-env.sh
+++ b/hack/test-env.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 export GATEWAY_API_VERSION="v0.8.1"
-export ISTIO_VERSION="1.19.0"
+export ISTIO_VERSION="1.19.3"
 export ISTIO_UNSUPPORTED_E2E_TESTS="retry,httpoption"
 export CONTOUR_VERSION="v1.26.0"
 export CONTOUR_UNSUPPORTED_E2E_TESTS="httpoption,basics/http2,grpc,grpc/split,update"


### PR DESCRIPTION
This patch mumps istio tested version to 1.19.3 which fixes the security vulnerabilities.