### PR TITLE
Filter IngressTLS for visibility IngressVisibilityExternalIP

### DIFF
--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -110,8 +110,9 @@ func (c *Reconciler) reconcileIngress(ctx context.Context, ing *v1alpha1.Ingress
 		}
 	}
 
-	listeners := make([]*gatewayapi.Listener, 0, len(ing.Spec.TLS))
-	for _, tls := range ing.Spec.TLS {
+	externalIngressTLS := ing.GetIngressTLSForVisibility(v1alpha1.IngressVisibilityExternalIP)
+	listeners := make([]*gatewayapi.Listener, 0, len(externalIngressTLS))
+	for _, tls := range externalIngressTLS {
 		tls := tls
 
 		l, err := c.reconcileTLS(ctx, &tls, ing)

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -284,7 +284,7 @@ func TestReconcileTLS(t *testing.T) {
 			rp(secret(secretName, nsName)),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: gw(defaultListener, tlsListener("secure.example.com", nsName, secretName)),
+			Object: gw(defaultListener, tlsListener("example.com", nsName, secretName)),
 		}},
 		WantPatches: []clientgotesting.PatchActionImpl{{
 			ActionImpl: clientgotesting.ActionImpl{
@@ -315,7 +315,7 @@ func TestReconcileTLS(t *testing.T) {
 		Objects: []runtime.Object{
 			ing(withBasicSpec, withFinalizer, withGatewayAPIClass, withTLS()),
 			secret(secretName, nsName),
-			gw(defaultListener, tlsListener("secure.example.com", nsName, secretName)),
+			gw(defaultListener, tlsListener("example.com", nsName, secretName)),
 			httpRoute(t, ing(withBasicSpec, withGatewayAPIClass, withTLS())),
 			rp(secret(secretName, nsName)),
 		},
@@ -602,7 +602,7 @@ var withFinalizer = func(i *v1alpha1.Ingress) {
 func withTLS() IngressOption {
 	return func(i *v1alpha1.Ingress) {
 		i.Spec.TLS = append(i.Spec.TLS, v1alpha1.IngressTLS{
-			Hosts:           []string{"secure.example.com"},
+			Hosts:           []string{"example.com"},
 			SecretName:      "name-WE-STICK-A-LONG-UID-HERE",
 			SecretNamespace: "ns",
 		})


### PR DESCRIPTION
Although net-gateway-api does not (yet) support `cluster-local-domain-tls`, enabling the feature will create additional entries in `IngressTLS`. As net-gateway-api only expects entries for `IngressVisibilityExternalIP` visibilities, this PR filters them out to keep the existing behaviour.

# Changes
- Filter IngressTLS for visibility IngressVisibilityExternalIP

Partially https://github.com/knative/serving/issues/14624

/assign @dprotaso 
/assign @nak3 
/assign @skonto 
