### PR TITLE
Bump Contour to v1.28.1

### DIFF
--- a/docs/test-version.md
+++ b/docs/test-version.md
@@ -16,4 +16,4 @@ The following Gateway API version and Ingress were tested as part of the release
 | Ingress | Tested version          | Unavailable features           |
 | ------- | ----------------------- | ------------------------------ |
 | Istio   | v1.19.3     | retry,httpoption   |
-| Contour | v1.26.0    | httpoption,basics/http2,grpc,grpc/split,update |
+| Contour | v1.28.1    | httpoption,basics/http2,grpc,grpc/split,update |

--- a/hack/test-env.sh
+++ b/hack/test-env.sh
@@ -17,5 +17,5 @@
 export GATEWAY_API_VERSION="v0.8.1"
 export ISTIO_VERSION="1.19.3"
 export ISTIO_UNSUPPORTED_E2E_TESTS="retry,httpoption"
-export CONTOUR_VERSION="v1.26.0"
+export CONTOUR_VERSION="v1.28.1"
 export CONTOUR_UNSUPPORTED_E2E_TESTS="httpoption,basics/http2,grpc,grpc/split,update"


### PR DESCRIPTION
## Changes

- bump Contour version to 1.28.1

Fixes #622
