### PR TITLE
disable update test for istio

### DIFF
--- a/docs/test-version.md
+++ b/docs/test-version.md
@@ -15,5 +15,5 @@ The following Gateway API version and Ingress were tested as part of the release
 
 | Ingress | Tested version          | Unavailable features           |
 | ------- | ----------------------- | ------------------------------ |
-| Istio   | v1.20.3     | retry,httpoption   |
+| Istio   | v1.20.3     | retry,httpoption,update   |
 | Contour | v1.28.1    | httpoption,basics/http2,grpc,grpc/split,update |

--- a/hack/test-env.sh
+++ b/hack/test-env.sh
@@ -16,6 +16,6 @@
 
 export GATEWAY_API_VERSION="v1.0.0"
 export ISTIO_VERSION="1.20.3"
-export ISTIO_UNSUPPORTED_E2E_TESTS="retry,httpoption"
+export ISTIO_UNSUPPORTED_E2E_TESTS="retry,httpoption,update"
 export CONTOUR_VERSION="v1.28.1"
 export CONTOUR_UNSUPPORTED_E2E_TESTS="httpoption,basics/http2,grpc,grpc/split,update"


### PR DESCRIPTION
Istio update test is very flakey - part of https://github.com/knative-extensions/net-gateway-api/issues/18