### PR TITLE
remove enableExternalNameService from external gateway config

### DIFF
--- a/third_party/contour/gateway-external.yaml
+++ b/third_party/contour/gateway-external.yaml
@@ -35,8 +35,6 @@ metadata:
   name: contour-external-gatewayclass
   namespace: contour-external
 spec:
-  runtimeSettings:
-    enableExternalNameService: true
   contour:
     deployment:
       replicas: 1


### PR DESCRIPTION
serving can handle returning an IP address via the KIngress and enableExternalNameService is false by default in contour

<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes
- remove enableExternalNameService from external gateway config
