### PR TITLE
Retry probing when status 500 is returned

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -515,7 +515,7 @@ func (m *Prober) probeVerifier(item *workItem) prober.Verifier {
 				return false, fmt.Errorf("unexpected version: want %q, got %q", item.ingressState.version, hash)
 			}
 
-		case http.StatusNotFound, http.StatusServiceUnavailable:
+		case http.StatusNotFound, http.StatusServiceUnavailable, http.StatusInternalServerError:
 			return false, fmt.Errorf("unexpected status code: want %v, got %v", http.StatusOK, r.StatusCode)
 
 		default:


### PR DESCRIPTION
# Changes

- :bug: http status 500 causes the ingress to be ready when probing

/kind bug

**Release Note**
```release-note
Report probing has failed and retry when receiving a http status 500
```