### PR TITLE
Fix probing when KIngress has multiple visibilities (External/ClusterLocal)

### DIFF
--- a/pkg/reconciler/ingress/fixtures_test.go
+++ b/pkg/reconciler/ingress/fixtures_test.go
@@ -36,6 +36,7 @@ type HTTPRoute struct {
 	Hostname         string
 	Rules            []RuleBuilder
 	StatusConditions []metav1.Condition
+	ClusterLocal     bool
 }
 
 func (r HTTPRoute) Build() *gatewayapi.HTTPRoute {
@@ -77,6 +78,11 @@ func (r HTTPRoute) Build() *gatewayapi.HTTPRoute {
 				}},
 			},
 		},
+	}
+
+	if r.ClusterLocal {
+		route.Labels[networking.VisibilityLabelKey] = "cluster-local"
+		route.Spec.CommonRouteSpec.ParentRefs[0].Name = gatewayapi.ObjectName(privateName)
 	}
 
 	for _, hostname := range hostnames {

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -1684,6 +1684,104 @@ func TestReconcileProbing(t *testing.T) {
 				}},
 			}.Build(),
 		}},
+	}, {
+		Name: "multiple visibility - steady state - transition probing still not ready",
+		Key:  "ns/name",
+		Ctx: withStatusManager(&fakeStatusManager{
+			FakeIsProbeActive: func(types.NamespacedName) (status.ProbeState, bool) {
+				state := status.ProbeState{Ready: false, Version: "tr-ff3cee4d49fbd4547b85c63d56e88eb866d4043951761f069d6afe14a2e61970"}
+				return state, true
+			},
+			FakeDoProbes: func(context.Context, status.Backends) (status.ProbeState, error) {
+				return status.ProbeState{Ready: false}, nil
+			},
+		}),
+		Objects: append([]runtime.Object{
+			ing(
+				withBasicSpec,
+				withInternalSpec,
+				withSecondRevisionSpec,
+				withGatewayAPIclass,
+				withFinalizer,
+				makeItReady,
+				makeLoadBalancerNotReady,
+			),
+			HTTPRoute{
+				Name:      "example.com",
+				Namespace: "ns",
+				Hostname:  "example.com",
+				Rules: []RuleBuilder{
+					EndpointProbeRule{
+						Namespace: "ns",
+						Name:      "second-revision",
+						Hash:      "tr-ff3cee4d49fbd4547b85c63d56e88eb866d4043951761f069d6afe14a2e61970",
+						Port:      123,
+					},
+					NormalRule{
+						Namespace: "ns",
+						Name:      "second-revision",
+						Port:      123,
+						Weight:    100,
+					},
+					EndpointProbeRule{
+						Namespace: "ns",
+						Name:      "second-revision",
+						Path:      "/.well-known/knative/revision/ns/second-revision",
+						Hash:      "tr-ff3cee4d49fbd4547b85c63d56e88eb866d4043951761f069d6afe14a2e61970",
+						Port:      123,
+					},
+					EndpointProbeRule{
+						Namespace: "ns",
+						Name:      "goo",
+						Path:      "/.well-known/knative/revision/ns/goo",
+						Hash:      "tr-ff3cee4d49fbd4547b85c63d56e88eb866d4043951761f069d6afe14a2e61970",
+						Port:      123,
+					},
+				},
+				StatusConditions: []metav1.Condition{{
+					Type:   string(gatewayapi.RouteConditionAccepted),
+					Status: metav1.ConditionTrue,
+				}},
+			}.Build(),
+			HTTPRoute{
+				Name:         "foo.svc.cluster.local",
+				Namespace:    "ns",
+				Hostnames:    []string{"foo.svc", "foo.svc.cluster.local"},
+				ClusterLocal: true,
+				Rules: []RuleBuilder{
+					EndpointProbeRule{
+						Namespace: "ns",
+						Name:      "second-revision",
+						Hash:      "tr-ff3cee4d49fbd4547b85c63d56e88eb866d4043951761f069d6afe14a2e61970",
+						Port:      124,
+					},
+					NormalRule{
+						Namespace: "ns",
+						Name:      "second-revision",
+						Port:      124,
+						Weight:    100,
+					},
+					EndpointProbeRule{
+						Namespace: "ns",
+						Name:      "second-revision",
+						Path:      "/.well-known/knative/revision/ns/second-revision",
+						Hash:      "tr-ff3cee4d49fbd4547b85c63d56e88eb866d4043951761f069d6afe14a2e61970",
+						Port:      124,
+					},
+					EndpointProbeRule{
+						Namespace: "ns",
+						Name:      "goo",
+						Path:      "/.well-known/knative/revision/ns/goo",
+						Hash:      "tr-ff3cee4d49fbd4547b85c63d56e88eb866d4043951761f069d6afe14a2e61970",
+						Port:      124,
+					},
+				},
+				StatusConditions: []metav1.Condition{{
+					Type:   string(gatewayapi.RouteConditionAccepted),
+					Status: metav1.ConditionTrue,
+				}},
+			}.Build(),
+		}, servicesAndEndpoints...),
 	}}
 
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -915,7 +915,7 @@ func TestReconcileProbing(t *testing.T) {
 		},
 			servicesAndEndpoints...),
 	}, {
-		Name: "transition probe complete - drop endpoint probes",
+		Name: "transition probe complete - drop probes",
 		Key:  "ns/name",
 		Ctx: withStatusManager(&fakeStatusManager{
 			FakeIsProbeActive: func(types.NamespacedName) (status.ProbeState, bool) {
@@ -1782,6 +1782,154 @@ func TestReconcileProbing(t *testing.T) {
 				}},
 			}.Build(),
 		}, servicesAndEndpoints...),
+	}, {
+		Name: "multiple visibility - transition complete - drop probes",
+		Key:  "ns/name",
+		Ctx: withStatusManager(&fakeStatusManager{
+			FakeIsProbeActive: func(types.NamespacedName) (status.ProbeState, bool) {
+				state := status.ProbeState{Ready: true, Version: "tr-ff3cee4d49fbd4547b85c63d56e88eb866d4043951761f069d6afe14a2e61970"}
+				return state, true
+			},
+			FakeDoProbes: func(context.Context, status.Backends) (status.ProbeState, error) {
+				return status.ProbeState{Ready: false}, nil
+			},
+		}),
+		Objects: append([]runtime.Object{
+			ing(
+				withBasicSpec,
+				withInternalSpec,
+				withSecondRevisionSpec,
+				withGatewayAPIclass,
+				withFinalizer,
+				makeItReady,
+				makeLoadBalancerNotReady,
+			),
+			HTTPRoute{
+				Name:      "example.com",
+				Namespace: "ns",
+				Hostname:  "example.com",
+				Rules: []RuleBuilder{
+					EndpointProbeRule{
+						Namespace: "ns",
+						Name:      "second-revision",
+						Hash:      "tr-ff3cee4d49fbd4547b85c63d56e88eb866d4043951761f069d6afe14a2e61970",
+						Port:      123,
+					},
+					NormalRule{
+						Namespace: "ns",
+						Name:      "second-revision",
+						Port:      123,
+						Weight:    100,
+					},
+					EndpointProbeRule{
+						Namespace: "ns",
+						Name:      "second-revision",
+						Path:      "/.well-known/knative/revision/ns/second-revision",
+						Hash:      "tr-ff3cee4d49fbd4547b85c63d56e88eb866d4043951761f069d6afe14a2e61970",
+						Port:      123,
+					},
+					EndpointProbeRule{
+						Namespace: "ns",
+						Name:      "goo",
+						Path:      "/.well-known/knative/revision/ns/goo",
+						Hash:      "tr-ff3cee4d49fbd4547b85c63d56e88eb866d4043951761f069d6afe14a2e61970",
+						Port:      123,
+					},
+				},
+				StatusConditions: []metav1.Condition{{
+					Type:   string(gatewayapi.RouteConditionAccepted),
+					Status: metav1.ConditionTrue,
+				}},
+			}.Build(),
+			HTTPRoute{
+				Name:         "foo.svc.cluster.local",
+				Namespace:    "ns",
+				Hostnames:    []string{"foo.svc", "foo.svc.cluster.local"},
+				ClusterLocal: true,
+				Rules: []RuleBuilder{
+					EndpointProbeRule{
+						Namespace: "ns",
+						Name:      "second-revision",
+						Hash:      "tr-ff3cee4d49fbd4547b85c63d56e88eb866d4043951761f069d6afe14a2e61970",
+						Port:      124,
+					},
+					NormalRule{
+						Namespace: "ns",
+						Name:      "second-revision",
+						Port:      124,
+						Weight:    100,
+					},
+					EndpointProbeRule{
+						Namespace: "ns",
+						Name:      "second-revision",
+						Path:      "/.well-known/knative/revision/ns/second-revision",
+						Hash:      "tr-ff3cee4d49fbd4547b85c63d56e88eb866d4043951761f069d6afe14a2e61970",
+						Port:      124,
+					},
+					EndpointProbeRule{
+						Namespace: "ns",
+						Name:      "goo",
+						Path:      "/.well-known/knative/revision/ns/goo",
+						Hash:      "tr-ff3cee4d49fbd4547b85c63d56e88eb866d4043951761f069d6afe14a2e61970",
+						Port:      124,
+					},
+				},
+				StatusConditions: []metav1.Condition{{
+					Type:   string(gatewayapi.RouteConditionAccepted),
+					Status: metav1.ConditionTrue,
+				}},
+			}.Build(),
+		}, servicesAndEndpoints...),
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: HTTPRoute{
+				Name:      "example.com",
+				Namespace: "ns",
+				Hostname:  "example.com",
+				Rules: []RuleBuilder{
+					EndpointProbeRule{
+						Namespace: "ns",
+						Name:      "second-revision",
+						Hash:      "ff3cee4d49fbd4547b85c63d56e88eb866d4043951761f069d6afe14a2e61970",
+						Port:      123,
+					},
+					NormalRule{
+						Namespace: "ns",
+						Name:      "second-revision",
+						Port:      123,
+						Weight:    100,
+					},
+				},
+				StatusConditions: []metav1.Condition{{
+					Type:   string(gatewayapi.RouteConditionAccepted),
+					Status: metav1.ConditionTrue,
+				}},
+			}.Build(),
+		}, {
+			Object: HTTPRoute{
+				Name:         "foo.svc.cluster.local",
+				Namespace:    "ns",
+				Hostnames:    []string{"foo.svc", "foo.svc.cluster.local"},
+				ClusterLocal: true,
+				Rules: []RuleBuilder{
+					EndpointProbeRule{
+						Namespace: "ns",
+						Name:      "second-revision",
+						Hash:      "ff3cee4d49fbd4547b85c63d56e88eb866d4043951761f069d6afe14a2e61970",
+						Port:      124,
+					},
+					NormalRule{
+						Namespace: "ns",
+						Name:      "second-revision",
+						Port:      124,
+						Weight:    100,
+					},
+				},
+				StatusConditions: []metav1.Condition{{
+					Type:   string(gatewayapi.RouteConditionAccepted),
+					Status: metav1.ConditionTrue,
+				}},
+			}.Build(),
+		}},
 	}}
 
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -472,7 +472,7 @@ func TestReconcileProbing(t *testing.T) {
 		Name: "updated ingress - new backends used for endpoint probing",
 		Key:  "ns/name",
 		Objects: append([]runtime.Object{
-			ing(withSecondRevisionSpec, withGatewayAPIclass, withFinalizer, makeItReady),
+			ing(withBasicSpec, withSecondRevisionSpec, withGatewayAPIclass, withFinalizer, makeItReady),
 			httpRoute(t, ing(withBasicSpec, withGatewayAPIclass), httpRouteReady),
 		}, servicesAndEndpoints...),
 		Ctx: withStatusManager(&fakeStatusManager{
@@ -484,7 +484,9 @@ func TestReconcileProbing(t *testing.T) {
 			},
 		}),
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: ing(withSecondRevisionSpec,
+			Object: ing(
+				withBasicSpec,
+				withSecondRevisionSpec,
 				withGatewayAPIclass,
 				withFinalizer,
 				makeItReady,
@@ -545,7 +547,8 @@ func TestReconcileProbing(t *testing.T) {
 			},
 		}),
 		Objects: append([]runtime.Object{
-			ing(withSecondRevisionSpec,
+			ing(withBasicSpec,
+				withSecondRevisionSpec,
 				withGatewayAPIclass,
 				withFinalizer,
 				makeItReady,
@@ -602,7 +605,8 @@ func TestReconcileProbing(t *testing.T) {
 			},
 		}),
 		Objects: append([]runtime.Object{
-			ing(withSecondRevisionSpec,
+			ing(withBasicSpec,
+				withSecondRevisionSpec,
 				withGatewayAPIclass,
 				withFinalizer,
 				makeItReady,
@@ -698,7 +702,8 @@ func TestReconcileProbing(t *testing.T) {
 			},
 		}),
 		Objects: append([]runtime.Object{
-			ing(withSecondRevisionSpec,
+			ing(withBasicSpec,
+				withSecondRevisionSpec,
 				withGatewayAPIclass,
 				withFinalizer,
 				makeItReady,
@@ -922,7 +927,8 @@ func TestReconcileProbing(t *testing.T) {
 			},
 		}),
 		Objects: append([]runtime.Object{
-			ing(withSecondRevisionSpec,
+			ing(withBasicSpec,
+				withSecondRevisionSpec,
 				withGatewayAPIclass,
 				withFinalizer,
 				makeItReady,
@@ -998,14 +1004,16 @@ func TestReconcileProbing(t *testing.T) {
 			},
 		}),
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: ing(withSecondRevisionSpec,
+			Object: ing(withBasicSpec,
+				withSecondRevisionSpec,
 				withGatewayAPIclass,
 				withFinalizer,
 				makeItReady,
 			),
 		}},
 		Objects: append([]runtime.Object{
-			ing(withSecondRevisionSpec,
+			ing(withBasicSpec,
+				withSecondRevisionSpec,
 				withGatewayAPIclass,
 				withFinalizer,
 				makeItReady,
@@ -1051,7 +1059,8 @@ func TestReconcileProbing(t *testing.T) {
 			},
 		}),
 		Objects: append([]runtime.Object{
-			ing(withSecondRevisionSpec,
+			ing(withBasicSpec,
+				withSecondRevisionSpec,
 				withGatewayAPIclass,
 				withFinalizer,
 				makeItReady,
@@ -1109,7 +1118,13 @@ func TestReconcileProbing(t *testing.T) {
 			},
 		}),
 		Objects: append([]runtime.Object{
-			ing(withThirdRevisionSpec, withGatewayAPIclass, withFinalizer, makeItReady, makeLoadBalancerNotReady),
+			ing(
+				withBasicSpec,
+				withThirdRevisionSpec,
+				withGatewayAPIclass,
+				withFinalizer,
+				makeItReady,
+				makeLoadBalancerNotReady),
 			HTTPRoute{
 				Name:      "example.com",
 				Namespace: "ns",
@@ -1230,6 +1245,162 @@ func TestReconcileProbing(t *testing.T) {
 						Headers:   []string{"key", "value"},
 						Port:      123,
 						Weight:    100,
+					},
+				},
+				StatusConditions: []metav1.Condition{{
+					Type:   string(gatewayapi.RouteConditionAccepted),
+					Status: metav1.ConditionTrue,
+				}},
+			}.Build(),
+		}},
+	}, {
+		Name: "multiple visibility - updated ingress - new backends used for endpoint probing",
+		Key:  "ns/name",
+		Objects: append([]runtime.Object{
+			ing(
+				withBasicSpec,
+				withInternalSpec,
+				withSecondRevisionSpec,
+				withGatewayAPIclass,
+				withFinalizer,
+				makeItReady),
+			HTTPRoute{
+				Name:      "example.com",
+				Namespace: "ns",
+				Hostname:  "example.com",
+				Rules: []RuleBuilder{
+					EndpointProbeRule{
+						Namespace: "ns",
+						Name:      "goo",
+						Hash:      "first-hash",
+						Port:      123,
+					},
+					NormalRule{
+						Namespace: "ns",
+						Name:      "goo",
+						Port:      123,
+						Weight:    100,
+					},
+				},
+				StatusConditions: []metav1.Condition{{
+					Type:   string(gatewayapi.RouteConditionAccepted),
+					Status: metav1.ConditionTrue,
+				}},
+			}.Build(),
+			HTTPRoute{
+				Name:         "foo.svc.cluster.local",
+				Namespace:    "ns",
+				Hostnames:    []string{"foo.svc", "foo.svc.cluster.local"},
+				ClusterLocal: true,
+				Rules: []RuleBuilder{
+					EndpointProbeRule{
+						Namespace: "ns",
+						Name:      "goo",
+						Hash:      "first-hash",
+						Port:      124,
+					},
+					NormalRule{
+						Namespace: "ns",
+						Name:      "goo",
+						Port:      124,
+						Weight:    100,
+					},
+				},
+				StatusConditions: []metav1.Condition{{
+					Type:   string(gatewayapi.RouteConditionAccepted),
+					Status: metav1.ConditionTrue,
+				}},
+			}.Build(),
+		}, servicesAndEndpoints...),
+		Ctx: withStatusManager(&fakeStatusManager{
+			FakeIsProbeActive: func(types.NamespacedName) (status.ProbeState, bool) {
+				return status.ProbeState{Ready: true, Version: "previous"}, true
+			},
+			FakeDoProbes: func(context.Context, status.Backends) (status.ProbeState, error) {
+				return status.ProbeState{Ready: false}, nil
+			},
+		}),
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: ing(
+				withBasicSpec,
+				withInternalSpec,
+				withSecondRevisionSpec,
+				withGatewayAPIclass,
+				withFinalizer,
+				makeItReady,
+				makeLoadBalancerNotReady,
+			),
+		}},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: HTTPRoute{
+				Name:      "example.com",
+				Namespace: "ns",
+				Hostname:  "example.com",
+				Rules: []RuleBuilder{
+					EndpointProbeRule{
+						Namespace: "ns",
+						Name:      "goo",
+						Hash:      "ep-ff3cee4d49fbd4547b85c63d56e88eb866d4043951761f069d6afe14a2e61970",
+						Port:      123,
+					},
+					NormalRule{
+						Namespace: "ns",
+						Name:      "goo",
+						Port:      123,
+						Weight:    100,
+					},
+					EndpointProbeRule{
+						Namespace: "ns",
+						Name:      "second-revision",
+						Path:      "/.well-known/knative/revision/ns/second-revision",
+						Hash:      "ep-ff3cee4d49fbd4547b85c63d56e88eb866d4043951761f069d6afe14a2e61970",
+						Port:      123,
+					},
+					EndpointProbeRule{
+						Namespace: "ns",
+						Name:      "goo",
+						Path:      "/.well-known/knative/revision/ns/goo",
+						Hash:      "ep-ff3cee4d49fbd4547b85c63d56e88eb866d4043951761f069d6afe14a2e61970",
+						Port:      123,
+					},
+				},
+				StatusConditions: []metav1.Condition{{
+					Type:   string(gatewayapi.RouteConditionAccepted),
+					Status: metav1.ConditionTrue,
+				}},
+			}.Build(),
+		}, {
+			Object: HTTPRoute{
+				Name:         "foo.svc.cluster.local",
+				Namespace:    "ns",
+				Hostnames:    []string{"foo.svc", "foo.svc.cluster.local"},
+				ClusterLocal: true,
+				Rules: []RuleBuilder{
+					EndpointProbeRule{
+						Namespace: "ns",
+						Name:      "goo",
+						Hash:      "ep-ff3cee4d49fbd4547b85c63d56e88eb866d4043951761f069d6afe14a2e61970",
+						Port:      124,
+					},
+					NormalRule{
+						Namespace: "ns",
+						Name:      "goo",
+						Port:      124,
+						Weight:    100,
+					},
+					EndpointProbeRule{
+						Namespace: "ns",
+						Name:      "second-revision",
+						Path:      "/.well-known/knative/revision/ns/second-revision",
+						Hash:      "ep-ff3cee4d49fbd4547b85c63d56e88eb866d4043951761f069d6afe14a2e61970",
+						Port:      124,
+					},
+					EndpointProbeRule{
+						Namespace: "ns",
+						Name:      "goo",
+						Path:      "/.well-known/knative/revision/ns/goo",
+						Hash:      "ep-ff3cee4d49fbd4547b85c63d56e88eb866d4043951761f069d6afe14a2e61970",
+						Port:      124,
 					},
 				},
 				StatusConditions: []metav1.Condition{{

--- a/pkg/reconciler/ingress/lister_test.go
+++ b/pkg/reconciler/ingress/lister_test.go
@@ -431,7 +431,7 @@ var (
 
 func withBasicSpec(i *v1alpha1.Ingress) {
 	i.Spec.HTTPOption = v1alpha1.HTTPOptionEnabled
-	i.Spec.Rules = append(i.Spec.Rules, v1alpha1.IngressRule{
+	i.Spec.Rules = []v1alpha1.IngressRule{{
 		Hosts:      []string{"example.com"},
 		Visibility: v1alpha1.IngressVisibilityExternalIP,
 		HTTP: &v1alpha1.HTTPIngressRuleValue{
@@ -450,17 +450,17 @@ func withBasicSpec(i *v1alpha1.Ingress) {
 				}},
 			}},
 		},
-	})
+	}}
 }
 
 func withSecondRevisionSpec(i *v1alpha1.Ingress) {
-	withBasicSpec(i)
-	i.Spec.Rules[0].HTTP.Paths[0].Splits[0].ServiceName = "second-revision"
-	i.Spec.Rules[0].HTTP.Paths[0].Splits[0].AppendHeaders["K-Serving-Revision"] = "second-revision"
+	for idx := range i.Spec.Rules {
+		i.Spec.Rules[idx].HTTP.Paths[0].Splits[0].ServiceName = "second-revision"
+		i.Spec.Rules[idx].HTTP.Paths[0].Splits[0].AppendHeaders["K-Serving-Revision"] = "second-revision"
+	}
 }
 
 func withThirdRevisionSpec(i *v1alpha1.Ingress) {
-	withBasicSpec(i)
 	i.Spec.Rules[0].HTTP.Paths[0].Splits[0].ServiceName = "third-revision"
 	i.Spec.Rules[0].HTTP.Paths[0].Splits[0].AppendHeaders["K-Serving-Revision"] = "third-revision"
 }


### PR DESCRIPTION
Serving uses multiple visibilities in it's KIngress which triggered a problem in the three phase probing.

This issue fixes that problem and adds the serving specific test cases

Fixes: https://github.com/knative-extensions/net-gateway-api/issues/18

Unblocks - https://github.com/knative/serving/pull/15136