### PR TITLE
Don't probe all the cluster local hosts 

### DIFF
--- a/pkg/reconciler/ingress/reconcile_resources.go
+++ b/pkg/reconciler/ingress/reconcile_resources.go
@@ -64,11 +64,19 @@ func probeTargets(
 	}
 
 	for _, rule := range r.Spec.Rules {
+	match_loop:
 		for _, match := range rule.Matches {
 			for _, headers := range match.Headers {
 				// Skip non-probe matches
 				if headers.Name != header.HashKey {
 					continue
+				}
+
+				if visibility == netv1alpha1.IngressVisibilityClusterLocal {
+					host := resources.LongestHost(r.Spec.Hostnames)
+					url := url.URL{Host: string(host), Path: *match.Path.Value}
+					backends.AddURL(visibility, url)
+					continue match_loop
 				}
 
 				for _, hostname := range r.Spec.Hostnames {

--- a/pkg/reconciler/ingress/resources/helpers.go
+++ b/pkg/reconciler/ingress/resources/helpers.go
@@ -17,7 +17,8 @@ limitations under the License.
 package resources
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 )
 
 // LongestHost returns the most specific host.
@@ -32,7 +33,7 @@ import (
 //   - hello.default
 //   - hello.default.svc
 //   - hello.default.svc.cluster.local
-func LongestHost(hosts []string) string {
-	sort.Strings(hosts)
+func LongestHost[S ~[]E, E cmp.Ordered](hosts S) E {
+	slices.Sort(hosts)
 	return hosts[len(hosts)-1]
 }


### PR DESCRIPTION
We only need to probe just one since we want to validate a
single backend is reachable.

Now we choose only the longest cluster local host