### PR TITLE
Fix probing getting stuck forever

### DIFF
--- a/pkg/reconciler/ingress/reconcile_resources.go
+++ b/pkg/reconciler/ingress/reconcile_resources.go
@@ -162,7 +162,11 @@ func (c *Reconciler) reconcileHTTPRouteUpdate(
 		for _, backend := range oldBackends {
 			resources.AddOldBackend(desired, hash, backend)
 		}
+	} else if probeHash == hash {
+		// Hash is the same but probes are not ready - continue
+		return httproute, probeTargets(probe.Version, ing, rule, httproute), nil
 	} else if len(newBackends) > 0 {
+		// Ingress changed with new backends
 		hash = endpointPrefix + hash
 		desired = httproute.DeepCopy()
 		resources.UpdateProbeHash(desired, hash)
@@ -173,14 +177,9 @@ func (c *Reconciler) reconcileHTTPRouteUpdate(
 		for _, backend := range oldBackends {
 			resources.AddOldBackend(desired, hash, backend)
 		}
-	} else if probeHash != hash {
-		desired, err = resources.MakeHTTPRoute(ctx, ing, rule)
 	} else {
-		// noop - preserve current probing
-		if probe.Version != "" {
-			hash = probe.Version
-		}
-		return httproute, probeTargets(hash, ing, rule, httproute), nil
+		// Ingress changed with the same backends
+		desired, err = resources.MakeHTTPRoute(ctx, ing, rule)
 	}
 
 	if err != nil {


### PR DESCRIPTION
A stale httproute in the informer cache can result in probing to get stuck.

This would cause the reconciler to detect a new backend and revert from
our 'transitioning' phase back to the endpoint phase.

The changes tweaks the state machine so that we only consider 'new'
backends if the ingress hash has changed.
