### PR TITLE
replace v1beta1 apis with v1 in yaml files

### DIFF
--- a/test/clients.go
+++ b/test/clients.go
@@ -27,7 +27,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
 	"sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
-	gatewayapi "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/typed/apis/v1beta1"
+	gatewayapi "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/typed/apis/v1"
 )
 
 // Clients holds instances of interfaces for making requests to Knative Serving.
@@ -82,6 +82,6 @@ func newGatewayAPIClients(cfg *rest.Config, namespace string) (*GatewayAPIClient
 		return nil, err
 	}
 	return &GatewayAPIClients{
-		HTTPRoutes: cs.GatewayV1beta1().HTTPRoutes(namespace),
+		HTTPRoutes: cs.GatewayV1().HTTPRoutes(namespace),
 	}, nil
 }

--- a/third_party/contour/gateway-external.yaml
+++ b/third_party/contour/gateway-external.yaml
@@ -18,7 +18,7 @@ metadata:
   name: contour-external
 ---
 kind: GatewayClass
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 metadata:
   name: contour-external
 spec:
@@ -44,7 +44,7 @@ spec:
       replicas: 1
 ---
 kind: Gateway
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 metadata:
   name: knative-external
   namespace: contour-external

--- a/third_party/contour/gateway-internal.yaml
+++ b/third_party/contour/gateway-internal.yaml
@@ -18,7 +18,7 @@ metadata:
   name: contour-internal
 ---
 kind: GatewayClass
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 metadata:
   name: contour-internal
 spec:
@@ -47,7 +47,7 @@ spec:
       replicas: 1
 ---
 kind: Gateway
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 metadata:
   name: knative-local
   namespace: contour-internal

--- a/third_party/istio/300-gateway-local.yaml
+++ b/third_party/istio/300-gateway-local.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 kind: Gateway
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 metadata:
   name: knative-local-gateway
   namespace: istio-system

--- a/third_party/istio/300-gateway.yaml
+++ b/third_party/istio/300-gateway.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 kind: Gateway
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 metadata:
   name: knative-gateway
   namespace: istio-system


### PR DESCRIPTION
# Changes

- replace v1beta1 apis with v1 in yaml files
- 

Relates to #687 