### PR TITLE
Promote Maturity Status to Beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Knative net-gateway-api
-**[This component is ALPHA](https://github.com/knative/community/tree/main/mechanics/MATURITY-LEVELS.md)**
+**[This component is Beta](https://github.com/knative/community/tree/main/mechanics/MATURITY-LEVELS.md)**
 
 [![GoDoc](https://godoc.org/knative-sandbox.dev/net-gateway-api?status.svg)](https://godoc.org/knative.dev/net-gateway-api)
 [![Go Report Card](https://goreportcard.com/badge/knative-sandbox/net-gateway-api)](https://goreportcard.com/report/knative-sandbox/net-gateway-api)


### PR DESCRIPTION
With the latest improvements to net-gateway-api and solidification of the config format (to match what we did in net-istio) 

I think we're good to mark this integration as beta so we get some more usage.