### PR TITLE
Use a different 'static' image that supports s390x and ppc

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,1 @@
+defaultBaseImage: ghcr.io/wolfi-dev/static:alpine


### PR DESCRIPTION
Updated image is recommended by Chainguard
Details here: https://www.chainguard.dev/unchained/changes-to-static-git-and-busybox-developer-images-2


## Release Note
```release-note
Support s390x/ppc when building our controllers
```
