### PR TITLE
Use shared go set-up action

### DIFF
--- a/.github/workflows/knative-dependabot.yaml
+++ b/.github/workflows/knative-dependabot.yaml
@@ -12,10 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-      - name: Set up Go 1.21.x
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.21.x
+      - name: Set up Go
+        uses: knative/actions/setup-go@main
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Changes
- Use shared go set-up action
- Indirectly bump to golang 1.22
- Should fix https://github.com/knative-extensions/net-gateway-api/actions/runs/10280449982/job/28447822704

/assign @dprotaso 
/assign @dsimansk 
