### PR TITLE
chore: Update README to use released version of net-gateway-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,7 @@ EOF
 
 ### Install net-gateway-api
 ```bash
-ko apply -f config/
-```
-
-### Load tested environment versions
-```
-source ./hack/test-env.sh
+kubectl apply -f https://github.com/knative-extensions/net-gateway-api/releases/latest/download/net-gateway-api.yaml
 ```
 
 ### Install a supported implementation


### PR DESCRIPTION
# Changes
- :broom: Update README.md to use released version of net-gateway-api

/kind documentation


<!-- Please include the 'why' behind your changes if no issue exists -->

**Now that net-gateway-api is in beta update the readme to use the released version**
