### PR TITLE
Fix stale knative-sandbox org references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Knative net-gateway-api
 **[This component is Beta](https://github.com/knative/community/tree/main/mechanics/MATURITY-LEVELS.md)**
 
-[![GoDoc](https://godoc.org/knative-sandbox.dev/net-gateway-api?status.svg)](https://godoc.org/knative.dev/net-gateway-api)
-[![Go Report Card](https://goreportcard.com/badge/knative-sandbox/net-gateway-api)](https://goreportcard.com/report/knative-sandbox/net-gateway-api)
+[![GoDoc](https://godoc.org/knative.dev/net-gateway-api?status.svg)](https://godoc.org/knative.dev/net-gateway-api)
+[![Go Report Card](https://goreportcard.com/badge/knative-extensions/net-gateway-api)](https://goreportcard.com/report/knative-extensions/net-gateway-api)
 
 net-gateway-api repository contains a KIngress implementation and testing for Knative integration with the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/).
 
@@ -16,8 +16,8 @@ Note: the integration is beta because some features are still missing. You can f
 
 We run our Knative Ingress Conformance tests and are tracking support by different implementations here:
 
-- [Contour Epic · Issue #384](https://github.com/knative-sandbox/net-gateway-api/issues/384)
-- [Istio EPIC · Issue #383](https://github.com/knative-sandbox/net-gateway-api/issues/383)
+- [Contour Epic · Issue #384](https://github.com/knative-extensions/net-gateway-api/issues/384)
+- [Istio EPIC · Issue #383](https://github.com/knative-extensions/net-gateway-api/issues/383)
 
 Versions to be installed are listed in [`hack/test-env.sh`](hack/test-env.sh).
 ---

--- a/pkg/reconciler/ingress/reconcile_resources.go
+++ b/pkg/reconciler/ingress/reconcile_resources.go
@@ -352,7 +352,7 @@ func (c *Reconciler) reconcileGatewayListeners(
 		lmap[string(l.Name)] = l
 	}
 	// TODO: how do we track and remove listeners if they are removed from the KIngress spec?
-	// Tracked in https://github.com/knative-sandbox/net-gateway-api/issues/319
+	// Tracked in https://github.com/knative-extensions/net-gateway-api/issues/319
 
 	updated := false
 	for i, l := range gw.Spec.Listeners {


### PR DESCRIPTION
## What

Update references to the old `knative-sandbox` GitHub org to the current `knative-extensions` org. The repo was moved but several links and badge URLs were not updated.

## Changes

- **README.md**: Fix GoDoc badge URL domain (`knative-sandbox.dev` → `knative.dev`)
- **README.md**: Fix Go Report Card badge org (`knative-sandbox` → `knative-extensions`)
- **README.md**: Fix conformance test epic links (issues #383, #384)
- **reconcile_resources.go**: Fix issue tracker comment URL (issue #319)

## Context

Found while reading through the codebase exploring ambient mesh support (ref: knative-extensions/net-istio#1360).

/kind cleanup